### PR TITLE
fix: change colors lime and pink based on style guide

### DIFF
--- a/src/components/UI/Button.tsx
+++ b/src/components/UI/Button.tsx
@@ -48,9 +48,9 @@ export const Button: FunctionComponent<ButtonProps> = (props) => {
     size === "small" ? "px-3 py-2 sm:px-4 text-xs" : "",
     !primary && !secondary ? "text-slate-700 bg-white hover:bg-slate-100" : "",
     secondary
-      ? "text-slate-900 tracking-tight bg-pink-600 hover:bg-pink-700"
+      ? "rounded text-white tracking-tight bg-pink-600 hover:bg-pink-200"
       : "",
-    primary ? "text-slate-900 tracking-tight bg-lime-400 hover:bg-lime-500" : ""
+    primary ? "rounded text-slate-800 tracking-tight bg-lime-600 hover:bg-lime-200" : ""
   );
 
   if (href) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,20 @@
 module.exports = {
   content: ["./src/**/*.{html,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        pink: {
+          DEFAULT: "#FF0063",
+          200: "#EFA8B8",
+          600: "#FF0063",
+        },
+        lime: {
+          DEFAULT: "#C4F30C",
+          200: "#E8FA9E",
+          600: "#C4F30C",
+        }
+      }
+    },
   },
   variants: {},
   plugins: [],


### PR DESCRIPTION
Change colors lime and pink for buttons based on style guide:

<img width="824" alt="Screenshot 2022-06-17 at 14 18 41" src="https://user-images.githubusercontent.com/6079870/174296774-8d3d79ef-71d6-45c2-a9ad-d9e5c5e942f1.png">

<img width="824" alt="Screenshot 2022-06-17 at 14 19 36" src="https://user-images.githubusercontent.com/6079870/174296834-bcb954fa-4eb5-429b-9371-d72ffd9841d5.png">

<img width="824" alt="Screenshot 2022-06-17 at 14 20 10" src="https://user-images.githubusercontent.com/6079870/174296913-f2ebb7c4-b079-40da-bf33-14c1e13f13ee.png">

<img width="824" alt="Screenshot 2022-06-17 at 14 20 24" src="https://user-images.githubusercontent.com/6079870/174296945-f34bfd03-92de-41c6-b313-7f734a9ccdb4.png">

