### PR TITLE
fix(Button): make tweaks in button styles

### DIFF
--- a/src/components/UI/Button.tsx
+++ b/src/components/UI/Button.tsx
@@ -34,20 +34,20 @@ const createStyles = ({
   secondary,
   darkMode,
 }: SharedButtonProps) => [
-  tw`flex items-center justify-center border border-transparent rounded-sm shadow-sm font-bold uppercase`,
-  !size && tw`text-sm px-4 py-3 sm:px-6`,
-  size === "large" && tw`px-6 py-4 sm:px-8 text-lg`,
-  size === "small" && tw`px-3 py-2 sm:px-4 text-xs`,
-  !primary &&
+    tw`flex items-center justify-center border border-transparent rounded-sm shadow-sm font-bold uppercase`,
+    !size && tw`text-sm px-4 py-3 sm:px-6`,
+    size === "large" && tw`px-8 py-4 sm:px-8 text-xs`,
+    size === "small" && tw`px-3 py-2 sm:px-4 text-xs`,
+    !primary &&
     !secondary &&
     (darkMode
       ? tw`bg-slate-800 text-slate-200 border border-slate-200 hover:bg-slate-900`
       : tw`text-slate-700 bg-white border border-slate-700 hover:bg-slate-100`),
-  secondary &&
-    tw`rounded text-white tracking-tight bg-pink-600 hover:bg-pink-200`,
-  primary &&
-    tw`rounded text-slate-800 tracking-tight bg-lime-600 hover:bg-lime-200`,
-];
+    secondary &&
+    tw`rounded-md text-white tracking-tight bg-pink-600 hover:bg-pink-200`,
+    primary &&
+    tw`rounded-md text-slate-800 tracking-wider font-bold bg-lime-600 hover:bg-lime-200`,
+  ];
 
 export const AsButton = styled.button((props: SharedButtonProps) =>
   createStyles(props)


### PR DESCRIPTION
This pull request adds minor tweaks to the Button styles based on the new design and values from Figma. It now looks like this:

<img width="1440" alt="Screenshot 2022-06-28 at 16 45 57" src="https://user-images.githubusercontent.com/6079870/176208947-f660d48c-ea1b-422d-b036-2dc0092076cd.png">

