### PR TITLE
Update Navbar and Hero section to match the design

### DIFF
--- a/src/GlobalStyles.tsx
+++ b/src/GlobalStyles.tsx
@@ -6,7 +6,7 @@ import { useMode } from "./hooks/useMode";
 
 const customStyles = css`
   body {
-    -webkit-tap-highlight-color: ${theme`colors.lime.DEFAULT`};
+    -webkit-tap-highlight-color: ${theme`colors[mg-primary-light]`};
     ${tw`antialiased`}
   }
 `;

--- a/src/components/Marketing/Hero.stories.tsx
+++ b/src/components/Marketing/Hero.stories.tsx
@@ -49,7 +49,7 @@ export default {
   args: {
     leader: "Online Courses Branded for Your Coding School to",
     title: "Offer Your Students and Teachers the Courses They Deserve",
-    follower: "Pay per active use license fee.",
+    follower: "Pay per active use license fee",
     primaryCTA: {
       href: "/join",
       label: "Join the Beta",

--- a/src/components/Marketing/Hero.tsx
+++ b/src/components/Marketing/Hero.tsx
@@ -49,7 +49,7 @@ export const Hero: FunctionComponent<HeroProps> = ({
   return (
     <div tw="relative">
       <Inset />
-      <div tw="max-w-7xl mx-auto sm:px-6 lg:px-8">
+      <div tw="max-w-7xl mx-auto">
         <div tw="relative sm:overflow-hidden">
           <div tw="absolute inset-0">
             {image && (
@@ -67,12 +67,14 @@ export const Hero: FunctionComponent<HeroProps> = ({
             )}
           </div>
           {header && <div tw="z-50 relative px-4 py-4 -mb-16">{header}</div>}
-          <div tw="relative px-4 py-16 sm:px-6 sm:py-24 lg:py-32 lg:px-8">
-            <h1 tw="text-4xl font-extrabold lg:text-center sm:text-5xl lg:text-6xl">
-              {leader && <span tw="block text-gray-200 text-sm">{leader}</span>}
-              <span tw="block text-white font-serif mt-4 tracking-tight">
-                {title}
-              </span>
+          <div tw="relative px-4 py-16 sm:px-6 sm:py-24 lg:py-32 lg:px-8 text-center">
+            <h1 tw="text-4xl md:max-w-2xl mx-auto font-bold font-serif pb-2 lg:pb-4 tracking-tight">
+              {leader && (
+                <span tw="block font-sans text-white text-lg pb-0">
+                  {leader}
+                </span>
+              )}
+              <span tw="block text-white font-serif mt-4">{title}</span>
             </h1>
             {follower && (
               <p tw="px-2 italic font-light mt-2 max-w-lg mx-auto lg:text-center text-base text-gray-300 sm:max-w-3xl">

--- a/src/components/UI/Button.tsx
+++ b/src/components/UI/Button.tsx
@@ -34,7 +34,7 @@ const createStyles = ({
   secondary,
   darkMode,
 }: SharedButtonProps) => [
-  tw`inline-flex items-center border border-transparent rounded-md shadow-sm font-bold uppercase tracking-wide`,
+  tw`inline-flex items-center border border-transparent rounded-md hover:shadow-sm font-bold uppercase tracking-wide`,
   !size && tw`text-sm px-8 py-3`,
   size === "large" && tw`px-8 py-3 sm:px-8 text-sm`,
   size === "small" && tw`px-3 py-2 sm:px-4 text-xs`,

--- a/src/components/UI/Navbar.tsx
+++ b/src/components/UI/Navbar.tsx
@@ -28,9 +28,9 @@ export type NavbarProps = {
 
 const NavbarLinkElement = styled.a(
   ({ current, darkBackground }: NavbarLinkProps) => [
-    tw`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium uppercase`,
-    current && darkBackground && tw`border-lime text-white`,
-    current && !darkBackground && tw`border-lime text-gray-900`,
+    tw`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-bold uppercase tracking-widest`,
+    current && darkBackground && tw`border-mg-primary text-white`,
+    current && !darkBackground && tw`border-mg-primary text-gray-900`,
     !darkBackground &&
       !current &&
       tw`border-transparent hover:border-gray-300 text-gray-500 hover:text-gray-700`,
@@ -92,7 +92,7 @@ export const Navbar: FunctionComponent<NavbarProps> = ({
                 </div>
                 <div tw="-mr-2 flex items-center sm:hidden">
                   {/* Mobile menu button */}
-                  <Disclosure.Button tw="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-lime">
+                  <Disclosure.Button tw="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-lime-100">
                     <span tw="sr-only">Open main menu</span>
                     {open ? (
                       <XIcon tw="block h-6 w-6" aria-hidden="true" />
@@ -118,7 +118,7 @@ export const Navbar: FunctionComponent<NavbarProps> = ({
                       key={label}
                       as="a"
                       href={href}
-                      tw="bg-lime-200 border-lime text-gray-800 hover:bg-lime-100 block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
+                      tw="bg-lime-200 border-lime-100 text-gray-800 hover:bg-lime-100 block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
                     >
                       {label}
                     </Disclosure.Button>

--- a/src/components/UI/Navbar.tsx
+++ b/src/components/UI/Navbar.tsx
@@ -92,7 +92,7 @@ export const Navbar: FunctionComponent<NavbarProps> = ({
                 </div>
                 <div tw="-mr-2 flex items-center sm:hidden">
                   {/* Mobile menu button */}
-                  <Disclosure.Button tw="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-lime-100">
+                  <Disclosure.Button tw="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-mg-primary-light">
                     <span tw="sr-only">Open main menu</span>
                     {open ? (
                       <XIcon tw="block h-6 w-6" aria-hidden="true" />
@@ -118,7 +118,7 @@ export const Navbar: FunctionComponent<NavbarProps> = ({
                       key={label}
                       as="a"
                       href={href}
-                      tw="bg-lime-200 border-lime-100 text-gray-800 hover:bg-lime-100 block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
+                      tw="bg-mg-primary-light border-mg-primary-light text-gray-800 hover:bg-mg-primary block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
                     >
                       {label}
                     </Disclosure.Button>
@@ -127,7 +127,7 @@ export const Navbar: FunctionComponent<NavbarProps> = ({
                       key={label}
                       as="a"
                       href={href}
-                      tw="border-transparent text-gray-500 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
+                      tw="border-transparent text-gray-500 hover:bg-mg-accent hover:border-mg-subtle hover:text-mg-onyx block pl-3 pr-4 py-2 border-l-4 text-base font-medium"
                     >
                       {label}
                     </Disclosure.Button>


### PR DESCRIPTION
This pull request updates the styles of the navbar and hero section to match the design. This is what it looks like now:

<img width="1270" alt="Screenshot 2022-07-03 at 17 52 15" src="https://user-images.githubusercontent.com/6079870/177047334-5407618a-b389-41b8-98d5-a0c993aa3238.png">

